### PR TITLE
Init concept for beacon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM google/golang:latest
+
+MAINTAINER lighthouse
+
+WORKDIR /gopath/src/github.com/lighthouse/beacon
+
+ADD . /gopath/src/github.com/lighthouse/beacon/
+RUN go get github.com/lighthouse/beacon
+
+
+ENTRYPOINT ["/gopath/bin/beacon"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,56 @@
-beacon
-======
-
+# Beacon
 Software for exposing an open interface for Lighthouse on cloud providers.
+![beacon](http://i.imgur.com/OGIcqyq.png)
+
+## Download
+```
+go get github.com/lighthouse/beacon
+```
+
+## Build
+```
+go install github.com/lighthouse/beacon
+```
+
+## Run
+```
+$GOPATH/bin/beacon
+```
+
+### Arguments
+* ```-driver gce``` Driver to use when interfacing with the vm provider.
+* ```-h 0.0.0.0:5000``` Address to listen on when hosting the server.
+* ```-key server.key``` Path to private key used for hosting TLS connections.
+* ```-pem server.pem``` Path to Cert used for hosting TLS connections.
+* ```-token 123abc``` Authentication token used to grant access to the beacon api.
+
+
+
+## Docker Build
+```
+docker build -t beacon $GOPATH/src/github.com/lighthouse/beacon
+```
+
+## Docker Run
+```
+docker run -d -p 5000:5000 reg.rob-sheehy.com/beacon -h 0.0.0.0:5000
+```
+
+## Authentication
+To make successful api calls to beacon from a client you will need the generated auth Token which is logged on app startup.
+That token must be in the header of each request as "Token" to preform any api call. Otherwise you will be greeted with a 401 status code.
+
+## Drivers
+
+### Local
+Interfaces with [boot2docker](http://boot2docker.io/) and uses the address stored in ```$DOCKER_HOST``` to make requests. This also works if your running inside Docker such that you can use..
+```
+-e "DOCKER_HOST=tcp://your.docker.i.p:2375"
+```
+to manually declair the host of the Docker daemon. For example...
+```
+docker run -d -p 5000:5000 -e "DOCKER_HOST=tcp://192.168.59.103:2375" beacon -h 0.0.0.0:5000 -driver local
+```
+
+### GCE
+Interfaces with [Compute Engine](https://cloud.google.com/compute/) and requires that the hosting vm has "Compute" read/write privalages to the Project to detect existing vms.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,45 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+    "flag"
+    "net/http"
+    "encoding/hex"
+    "crypto/rand"
+
+    "github.com/zenazn/goji/web"
+)
+
+var Token = flag.String("token", GenerateToken(32), "Predefined auth token")
+
+func Middleware(c *web.C, h http.Handler) http.Handler {
+    fn := func(w http.ResponseWriter, r *http.Request) {
+        requestToken, ok := r.Header["Token"]
+        if ok && requestToken[0] == *Token {
+            h.ServeHTTP(w, r)
+        } else {
+            w.WriteHeader(401)
+        }
+    }
+
+    return http.HandlerFunc(fn)
+}
+
+func GenerateToken(size int) string {
+    token := make([]byte, size)
+    rand.Read(token)
+    return hex.EncodeToString(token)
+}

--- a/beacon.go
+++ b/beacon.go
@@ -35,8 +35,6 @@ import (
 )
 
 
-var err error
-
 var pemFile = flag.String("pem", "", "Path to Cert file")
 var keyFile = flag.String("key", "", "Path to Key file")
 var address = flag.String("h", "127.0.0.1:5000", "Address to host under")
@@ -120,6 +118,9 @@ func main() {
 
     http.Handle("/", App)
     log.Printf("Listening on %s", *address)
+
+
+    var err error
 
     if *pemFile != "" && *keyFile != "" {
         log.Printf("Setting up secure server...")

--- a/beacon.go
+++ b/beacon.go
@@ -1,0 +1,136 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+    "fmt"
+    "flag"
+    "log"
+    "net/http"
+    "encoding/json"
+    "io/ioutil"
+    "strings"
+
+    "github.com/mgutz/ansi"
+
+    "github.com/zenazn/goji/web"
+    "github.com/zenazn/goji/graceful"
+    "github.com/zenazn/goji/web/middleware"
+
+    "github.com/lighthouse/beacon/auth"
+    "github.com/lighthouse/beacon/drivers"
+    "github.com/lighthouse/beacon/structs"
+)
+
+
+var err error
+
+var pemFile = flag.String("pem", "", "Path to Cert file")
+var keyFile = flag.String("key", "", "Path to Key file")
+var address = flag.String("h", "127.0.0.1:5000", "Address to host under")
+
+var App *web.Mux
+var Driver *structs.Driver
+
+
+func init() {
+    App = web.New()
+    App.Use(middleware.Logger)
+    App.Use(auth.Middleware)
+
+    App.Handle("/d/*", func(c web.C, w http.ResponseWriter, r *http.Request) {
+        target := fmt.Sprintf("http://%s",
+            strings.SplitN(r.URL.Path, "/", 3)[2])
+
+        req, err := http.NewRequest(r.Method, target, r.Body)
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            fmt.Fprint(w, err)
+            return
+        }
+
+        resp, err := http.DefaultClient.Do(req)
+
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            fmt.Fprint(w, err)
+            return
+        }
+
+        body, err := ioutil.ReadAll(resp.Body)
+
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            fmt.Fprint(w, err)
+            return
+        }
+
+        w.WriteHeader(resp.StatusCode)
+        w.Write(body)
+    })
+
+    App.Get("/vms", func(c web.C, w http.ResponseWriter, r *http.Request) {
+        response, _ := json.Marshal(Driver.GetVMs())
+        w.Write(response)
+    })
+
+    App.Get("/which", func(c web.C, w http.ResponseWriter, r *http.Request) {
+        response, _ := json.Marshal(Driver.Name)
+        w.Write(response)
+    })
+
+    App.Compile()
+}
+
+
+func main() {
+    log.Printf(ansi.Color("Starting Beacon...", "white+b"))
+
+    if !flag.Parsed() {
+        flag.Parse()
+    }
+
+    Driver = drivers.Decide()
+
+    log.Printf("Provider Interface: %s\n", ansi.Color(Driver.Name, "cyan+b"))
+    log.Printf("Authentication Token: %s\n", ansi.Color(*auth.Token, "cyan+b"))
+
+    graceful.HandleSignals()
+
+    graceful.PreHook(func() {
+        log.Printf(ansi.Color("Gracefully Shutting Down...", "white+b"))
+    })
+    graceful.PostHook(func() {
+        log.Printf(ansi.Color("Done!", "white+b"))
+    })
+
+    defer graceful.Wait()
+
+    http.Handle("/", App)
+    log.Printf("Listening on %s", *address)
+
+    if *pemFile != "" && *keyFile != "" {
+        log.Printf("Setting up secure server...")
+        err = graceful.ListenAndServeTLS(*address, *pemFile, *keyFile, http.DefaultServeMux)
+    } else {
+        log.Printf(ansi.Color("Setting up unsecure server...", "yellow+b"))
+        err = graceful.ListenAndServe(*address, http.DefaultServeMux)
+    }
+
+
+    if err != nil {
+        log.Fatal(err)
+    }
+}

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -1,0 +1,60 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drivers
+
+
+import (
+    "flag"
+
+    "github.com/lighthouse/beacon/structs"
+
+    "github.com/lighthouse/beacon/drivers/gce"
+    "github.com/lighthouse/beacon/drivers/local"
+    "github.com/lighthouse/beacon/drivers/unknown"
+
+)
+
+var Preferred = flag.String("driver", "", "Specified driver to use")
+
+var Defaults = []*structs.Driver{
+    gce.Driver,
+    local.Driver,
+}
+
+
+func Decide() *structs.Driver {
+    if *Preferred != "" {
+        return Find(*Preferred, Defaults)
+    }
+    return Guess(Defaults)
+}
+
+func Find(preferred string, drivers []*structs.Driver) *structs.Driver {
+    for _, driver := range drivers {
+        if driver.Name == preferred {
+            return driver
+        }
+    }
+    return unknown.Driver
+}
+
+func Guess(drivers []*structs.Driver) *structs.Driver {
+    for _, driver := range drivers {
+        if driver.IsApplicable() {
+            return driver
+        }
+    }
+    return unknown.Driver
+}

--- a/drivers/gce/gce.go
+++ b/drivers/gce/gce.go
@@ -1,0 +1,102 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gce
+
+import (
+    "sync"
+    "net/http"
+    "io/ioutil"
+
+    "github.com/lighthouse/beacon/structs"
+
+    "code.google.com/p/gameboy1092-goauth2/compute/serviceaccount"
+    compute "code.google.com/p/google-api-go-client/compute/v1"
+)
+
+var Driver = &structs.Driver {
+    Name: "gce",
+    IsApplicable: IsApplicable,
+    GetVMs: GetProjectVMs,
+}
+
+func IsApplicable() bool {
+    request, _ := http.NewRequest("GET", "http://metadata.google.internal/", nil)
+    request.Header.Add("Metadata-Flavor", "Google")
+
+    client := http.Client{}
+    resp, err := client.Do(request)
+
+    return err == nil && resp.StatusCode == 200
+}
+
+func GetCurrentProjectID() (string, error) {
+    request, _ := http.NewRequest(
+        "GET", "http://metadata.google.internal/computeMetadata/v1/project/project-id", nil)
+
+    request.Header.Add("Metadata-Flavor", "Google")
+
+    client := http.Client{}
+    response, err := client.Do(request)
+    if err != nil {
+        return "", err
+    }
+
+    projectID, err := ioutil.ReadAll(response.Body)
+    if err != nil {
+        return "", err
+    }
+    response.Body.Close()
+
+    return string(projectID), nil
+}
+
+func GetProjectVMs() []*structs.VM {
+    client, _ := serviceaccount.NewClient(&serviceaccount.Options{})
+    computeClient, _ := compute.New(client)
+
+    projectID, _ := GetCurrentProjectID()
+
+    zones, _ := computeClient.Instances.AggregatedList(projectID).Do()
+
+    var discoveredVMs []*structs.VM
+
+    for _, zone := range zones.Items {
+        for _, instance := range zone.Instances {
+            // For future reference we need figure out which network interface
+            // to use instead of deafulting to the first one.
+            network := instance.NetworkInterfaces[0]
+
+            discoveredVMs = append(discoveredVMs, &structs.VM{
+                Name: instance.Name,
+                Address: network.NetworkIP,
+                Port: "2375",
+                Version: "v1",
+                CanAccessDocker: false,
+            })
+        }
+    }
+
+    var wg sync.WaitGroup
+    for _, vm := range discoveredVMs {
+        wg.Add(1)
+        go func(vm *structs.VM) {
+            defer wg.Done()
+            vm.CanAccessDocker = vm.PingDocker()
+        }(vm)
+    }
+    wg.Wait()
+
+    return discoveredVMs
+}

--- a/drivers/local/local.go
+++ b/drivers/local/local.go
@@ -1,0 +1,49 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+    "os"
+    "strings"
+
+    "github.com/lighthouse/beacon/structs"
+)
+
+var Driver = &structs.Driver {
+    Name: "local",
+    IsApplicable: IsApplicable,
+    GetVMs: GetVMS,
+}
+
+func IsApplicable() bool {
+    return os.Getenv("DOCKER_HOST") != ""
+}
+
+func GetVMS() []*structs.VM {
+    dockerHost := os.Getenv("DOCKER_HOST")
+    dockerHost = strings.Replace(dockerHost, "tcp://", "", 1)
+    hostInfo := strings.Split(dockerHost, ":")
+
+    boot2Docker := &structs.VM{
+        Name: "boot2docker",
+        Address: hostInfo[0],
+        Port: hostInfo[1],
+        Version: "v1",
+        CanAccessDocker: false,
+    }
+    boot2Docker.CanAccessDocker = boot2Docker.PingDocker()
+
+    return []*structs.VM{boot2Docker}
+}

--- a/drivers/unknown/unknown.go
+++ b/drivers/unknown/unknown.go
@@ -1,0 +1,33 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package unknown
+
+import (
+    "github.com/lighthouse/beacon/structs"
+)
+
+var Driver = &structs.Driver {
+    Name: "unknown",
+    IsApplicable: IsApplicable,
+    GetVMs: GetVMs,
+}
+
+func IsApplicable() bool {
+    return true
+}
+
+func GetVMs() []*structs.VM {
+    return []*structs.VM{}
+}

--- a/structs/driver.go
+++ b/structs/driver.go
@@ -1,0 +1,21 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structs
+
+type Driver struct {
+    Name string
+    IsApplicable func() bool
+    GetVMs func() []*VM
+}

--- a/structs/vm.go
+++ b/structs/vm.go
@@ -1,0 +1,41 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structs
+
+import (
+    "fmt"
+    "time"
+    "net/http"
+)
+
+type VM struct {
+    Name string `json:"name,omitempty"`
+    Address string `json:"address,omitempty"`
+    Port string `json:"port,omitempty"`
+    Version string `json:"version,omitempty"`
+    CanAccessDocker bool `json:"canAccessDocker"`
+}
+
+func (this *VM) PingDocker() bool {
+    pingAddress := fmt.Sprintf("http://%s:%s/%s/_ping",
+        this.Address, this.Port, this.Version)
+
+    client := &http.Client{
+        Timeout: time.Duration(2)*time.Second,
+    }
+    response, err := client.Get(pingAddress)
+
+    return err == nil && response.StatusCode == 200
+}


### PR DESCRIPTION
# Beacon

Software for exposing an open interface for Lighthouse on cloud providers.
![beacon](http://i.imgur.com/OGIcqyq.png)
## Download

```
go get github.com/lighthouse/beacon
```
## Build

```
go install github.com/lighthouse/beacon
```
## Run

```
$GOPATH/bin/beacon
```
### Arguments
- `-driver gce` Driver to use when interfacing with the vm provider.
- `-h 0.0.0.0:5000` Address to listen on when hosting the server.
- `-key server.key` Path to private key used for hosting TLS connections.
- `-pem server.pem` Path to Cert used for hosting TLS connections.
- `-token 123abc` Authentication token used to grant access to the beacon api.
## Docker Build

```
docker build -t beacon $GOPATH/src/github.com/lighthouse/beacon
```
## Docker Run

```
docker run -d -p 5000:5000 reg.rob-sheehy.com/beacon -h 0.0.0.0:5000
```
## Authentication

To make successful api calls to beacon from a client you will need the generated auth Token which is logged on app startup.
That token must be in the header of each request as "Token" to preform any api call. Otherwise you will be greeted with a 401 status code.
## Drivers
### Local

Interfaces with [boot2docker](http://boot2docker.io/) and uses the address stored in `$DOCKER_HOST` to make requests. This also works if your running inside Docker such that you can use..

```
-e "DOCKER_HOST=tcp://your.docker.i.p:2375"
```

to manually declair the host of the Docker daemon. For example...

```
docker run -d -p 5000:5000 -e "DOCKER_HOST=tcp://192.168.59.103:2375" beacon -h 0.0.0.0:5000 -driver local
```
### GCE

Interfaces with [Compute Engine](https://cloud.google.com/compute/) and requires that the hosting vm has "Compute" read/write privalages to the Project to detect existing vms.
