### PR TITLE
Boot2Docker Api version lookup

### DIFF
--- a/drivers/gce/gce.go
+++ b/drivers/gce/gce.go
@@ -94,6 +94,10 @@ func GetProjectVMs() []*structs.VM {
         go func(vm *structs.VM) {
             defer wg.Done()
             vm.CanAccessDocker = vm.PingDocker()
+
+            if vm.CanAccessDocker {
+                vm.Version, _ = vm.GetDockerVersion()
+            }
         }(vm)
     }
     wg.Wait()

--- a/drivers/local/local.go
+++ b/drivers/local/local.go
@@ -16,12 +16,7 @@ package local
 
 import (
     "os"
-    "fmt"
     "strings"
-
-    "net/http"
-    "io/ioutil"
-    "encoding/json"
 
     "github.com/lighthouse/beacon/structs"
 )
@@ -50,41 +45,9 @@ func GetVMS() []*structs.VM {
     }
     boot2Docker.CanAccessDocker = boot2Docker.PingDocker()
 
-    api, err := getDockerAPIVersion(dockerHost)
-
-    if err == nil {
-        boot2Docker.Version = api
+    if boot2Docker.CanAccessDocker {
+        boot2Docker.Version, _ = boot2Docker.GetDockerVersion()
     }
 
     return []*structs.VM{boot2Docker}
-}
-
-func getDockerAPIVersion(dockerHost string) (string, error){
-
-    target := fmt.Sprintf("http://%s/v1/version", dockerHost)
-
-    req, err := http.NewRequest("GET", target, nil)
-    if err != nil {
-        return "", err
-    }
-
-    resp, err := http.DefaultClient.Do(req)
-    if err != nil {
-        return "", err
-    }
-
-    defer resp.Body.Close()
-
-    body, err := ioutil.ReadAll(resp.Body)
-    if err != nil {
-        return "", err
-    }
-
-    var api struct {
-        ApiVersion string
-    }
-
-    err = json.Unmarshal(body, &api)
-
-    return fmt.Sprintf("v%s", api.ApiVersion), err
 }

--- a/drivers/local/local.go
+++ b/drivers/local/local.go
@@ -16,7 +16,12 @@ package local
 
 import (
     "os"
+    "fmt"
     "strings"
+
+    "net/http"
+    "io/ioutil"
+    "encoding/json"
 
     "github.com/lighthouse/beacon/structs"
 )
@@ -45,5 +50,41 @@ func GetVMS() []*structs.VM {
     }
     boot2Docker.CanAccessDocker = boot2Docker.PingDocker()
 
+    api, err := getDockerAPIVersion(dockerHost)
+
+    if err == nil {
+        boot2Docker.Version = api
+    }
+
     return []*structs.VM{boot2Docker}
+}
+
+func getDockerAPIVersion(dockerHost string) (string, error){
+
+    target := fmt.Sprintf("http://%s/v1/version", dockerHost)
+
+    req, err := http.NewRequest("GET", target, nil)
+    if err != nil {
+        return "", err
+    }
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        return "", err
+    }
+
+    defer resp.Body.Close()
+
+    body, err := ioutil.ReadAll(resp.Body)
+    if err != nil {
+        return "", err
+    }
+
+    var api struct {
+        ApiVersion string
+    }
+
+    err = json.Unmarshal(body, &api)
+
+    return fmt.Sprintf("v%s", api.ApiVersion), err
 }

--- a/structs/vm.go
+++ b/structs/vm.go
@@ -68,6 +68,9 @@ func (this *VM) GetDockerVersion() (string, error) {
     }
 
     err = json.Unmarshal(body, &api)
-
-    return fmt.Sprintf("v%s", api.ApiVersion), err
+    if err != nil {
+        return "v1", err
+    }
+    
+    return fmt.Sprintf("v%s", api.ApiVersion), nil
 }


### PR DESCRIPTION
Was running into some issues with beacon defaulting to API v1 when my local was v1.12.  With this beacon tries to look up Docker's version (by hitting `/v1/version`) and uses that version instead.
