### PR TITLE
Create a Config Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ Interfaces with [Compute Engine](https://cloud.google.com/compute/) and requires
 
 ### Digital Ocean
 Interfaces with [Digital Ocean](https://www.digitalocean.com/) and requires that an api token be set to the hosting vm's "User Data".  Read more info [here](https://github.com/lighthouse/beacon/pull/4).
+
+### Config
+Instead of relying on a provider api you can manually create a config file that list available ips of vms you want beacon to communicate with.
+For example all you have to do is drop a ```config.json``` into the running directory of Beacon and it will take care of the rest for you.
+A simple  ```config.json``` can look something like this.
+```JSON
+[
+    "192.168.59.103",
+    "127.0.0.1"
+]
+
+```

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ For example all you have to do is drop a ```config.json``` into the running dire
 A simple  ```config.json``` can look something like this.
 ```JSON
 [
-    "192.168.59.103",
-    "127.0.0.1"
+    {"Host": "192.168.59.103", "Port": "2375"},
+    {"Host": "127.0.0.1", "Port": "80"}
 ]
 
 ```

--- a/drivers/config/config.go
+++ b/drivers/config/config.go
@@ -1,0 +1,72 @@
+// Copyright 2014 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+    "os"
+    "sync"
+    "io/ioutil"
+    "encoding/json"
+
+    "github.com/lighthouse/beacon/structs"
+)
+
+var Driver = &structs.Driver {
+    Name: "config",
+    IsApplicable: IsApplicable,
+    GetVMs: GetVMs,
+}
+
+func IsApplicable() bool {
+    _, err := os.Stat("config.json")
+    return !os.IsNotExist(err)
+}
+
+func GetVMs() []*structs.VM {
+    file, e := ioutil.ReadFile("config.json")
+    var discoveredVMs []*structs.VM
+
+    if e != nil {
+        return discoveredVMs
+    }
+
+    var vmIps []string
+    json.Unmarshal(file, &vmIps)
+
+    var wg sync.WaitGroup
+    for _, vmIp := range vmIps {
+        vm := &structs.VM{
+            Name: vmIp,
+            Address: vmIp,
+            Port: "2375",
+            Version: "v1",
+            CanAccessDocker: false,
+        }
+
+        discoveredVMs = append(discoveredVMs, vm)
+
+        wg.Add(1)
+        go func(vm *structs.VM) {
+            defer wg.Done()
+            vm.CanAccessDocker = vm.PingDocker()
+
+            if vm.CanAccessDocker {
+                vm.Version, _ = vm.GetDockerVersion()
+            }
+        }(vm)
+    }
+    wg.Wait()
+    return discoveredVMs
+}

--- a/drivers/config/config.go
+++ b/drivers/config/config.go
@@ -16,12 +16,18 @@ package config
 
 import (
     "os"
+    "fmt"
     "sync"
     "io/ioutil"
     "encoding/json"
 
     "github.com/lighthouse/beacon/structs"
 )
+
+type HostConfig struct {
+    Host string
+    Port string
+}
 
 var Driver = &structs.Driver {
     Name: "config",
@@ -42,15 +48,15 @@ func GetVMs() []*structs.VM {
         return discoveredVMs
     }
 
-    var vmIps []string
-    json.Unmarshal(file, &vmIps)
+    var hostConfigs []*HostConfig
+    json.Unmarshal(file, &hostConfigs)
 
     var wg sync.WaitGroup
-    for _, vmIp := range vmIps {
+    for _, hostConfig := range hostConfigs {
         vm := &structs.VM{
-            Name: vmIp,
-            Address: vmIp,
-            Port: "2375",
+            Name: fmt.Sprintf("%s:%s", hostConfig.Host, hostConfig.Port),
+            Address: hostConfig.Host,
+            Port: hostConfig.Port,
             Version: "v1",
             CanAccessDocker: false,
         }

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -22,6 +22,7 @@ import (
 
     "github.com/lighthouse/beacon/drivers/gce"
     "github.com/lighthouse/beacon/drivers/ocean"
+    "github.com/lighthouse/beacon/drivers/config"
     "github.com/lighthouse/beacon/drivers/local"
     "github.com/lighthouse/beacon/drivers/unknown"
 
@@ -32,6 +33,7 @@ var Preferred = flag.String("driver", "", "Specified driver to use")
 var Defaults = []*structs.Driver{
     gce.Driver,
     ocean.Driver,
+    config.Driver,
     local.Driver,
 }
 


### PR DESCRIPTION
## What

Instead of relying on a provider api you can manually create a config file that lists available ips of vms you want beacon to communicate with. For example all you have to do is drop a `config.json` into the running directory of Beacon and it will take care of the rest for you. A simple  `config.json` can look something like this.

``` JSON
[
    {"Host": "192.168.59.103", "Port": "2375"},
    {"Host": "127.0.0.1", "Port": "80"}
]
```
