### PR TITLE
Ensure Content-Type is Persisted When Routing to Docker

### DIFF
--- a/beacon.go
+++ b/beacon.go
@@ -59,6 +59,9 @@ func init() {
             return
         }
 
+        // TESTING header addition
+        req.Header.Add("Content-Type", "application/json")
+
         resp, err := http.DefaultClient.Do(req)
 
         if err != nil {

--- a/beacon.go
+++ b/beacon.go
@@ -59,8 +59,10 @@ func init() {
             return
         }
 
-        // TESTING header addition
-        req.Header.Add("Content-Type", "application/json")
+        contentType := r.Header.Get("Content-Type")
+        if contentType != "" {
+            req.Header.Set("Content-Type", contentType)
+        }
 
         resp, err := http.DefaultClient.Do(req)
 


### PR DESCRIPTION
Shout out to @ngmiller for finding this bug that strips the `Content-Type` from request headers.
