### PR TITLE
Split on URL URL.String() rather than URL.Path

### DIFF
--- a/beacon.go
+++ b/beacon.go
@@ -50,7 +50,7 @@ func init() {
 
     App.Handle("/d/*", func(c web.C, w http.ResponseWriter, r *http.Request) {
         target := fmt.Sprintf("http://%s",
-            strings.SplitN(r.URL.Path, "/", 3)[2])
+            strings.SplitN(r.URL.String(), "/", 3)[2])
 
         req, err := http.NewRequest(r.Method, target, r.Body)
         if err != nil {


### PR DESCRIPTION
Did this because URL path does some magic bs parsing which takes out the query params.  To mitigate this problem we just use `URL.String()` instead of `URL.Path`.
Take for example the following string...

```
/d/192.168.59.103:2375/v1.12/images/search?term=lighthouse/beacon
```

`URL.Path` would return....

```
/d/192.168.59.103:2375/v1.12/images/search
```

`URL.String()` returns....

```
/d/192.168.59.103:2375/v1.12/images/search?term=lighthouse/beacon
```
