### PR TITLE
Experiment with possible solutions for streaming

### DIFF
--- a/beacon.go
+++ b/beacon.go
@@ -73,7 +73,7 @@ func init() {
         }
 
         w.WriteHeader(resp.StatusCode)
-        var bodyBuffer = make([]byte, 2048)
+        var bodyBuffer = make([]byte, 16)
 
         for {
             n, err := resp.Body.Read(bodyBuffer)


### PR DESCRIPTION
So I've found that `ioutil.ReadAll` will block a response until the request's response has been completed which is not idea if we are wanting to stream the status of image pulls or logs.  I've found by not using `ioutil.ReadAll` that we can actually buffer the response and return chunks of data back incrementally.  I haven't tested this much, but you'll notice a difference when running the following lines.

```
cd $GOPATH/src/github.com/lighthouse/beacon
git checkout master
go install .
$GOPATH/bin/beacon --token foobar
docker rmi ubuntu:latest
curl localhost:5000/d/192.168.59.103:2375/images/create?fromImage=ubuntu:latest

git checkout -b stream-test origin/stream-test
go install .
$GOPATH/bin/beacon --token foobar
docker rmi ubuntu:latest
curl localhost:5000/d/192.168.59.103:2375/images/create?fromImage=ubuntu:latest
```

You'll notice the second `curl` will incrementally update the status of the image create while the first one will block until the call has completed.
The only thing I'm not sure is how this will work with a client.  If I'm not mistaken any ajax call will block until the call has completed.  Second of all I'm not sure how to read a stream of JSON.
